### PR TITLE
feat(cb2-13187): feature flag for issue docs

### DIFF
--- a/packages/feature-flags/package.json
+++ b/packages/feature-flags/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dvsa/cvs-feature-flags",
-  "version": "0.13.0",
+  "version": "0.14.0",
   "description": "Common package to be used in CVS to manage feature flags",
   "author": "DVSA",
   "license": "ISC",

--- a/packages/feature-flags/src/config.ts
+++ b/packages/feature-flags/src/config.ts
@@ -2,7 +2,7 @@ interface IFeatureFlagsConfig {
   environment: string;
   application: string;
   maxAge: number;
-  requestTimeout: number
+  requestTimeout: number;
 }
 
 declare let process: {

--- a/packages/feature-flags/src/feature-flags.ts
+++ b/packages/feature-flags/src/feature-flags.ts
@@ -8,15 +8,12 @@ import { FeatureFlagsClientName } from './';
 
 class FeatureFlagsClient {
   async get<T>(clientName: FeatureFlagsClientName): Promise<T> {
-
     const featureFlags = await getAppConfig(`${clientName}-profile`, {
       ...defaultFeatureFlagConfig,
       transform: 'json',
     });
 
-
     return featureFlags as T;
-
   }
 }
 

--- a/packages/feature-flags/src/profiles/__tests__/vtx-profile.spec.ts
+++ b/packages/feature-flags/src/profiles/__tests__/vtx-profile.spec.ts
@@ -16,6 +16,7 @@ describe('app config configuration', () => {
 
     expect(flags.welshTranslation.enabled).toBe(false);
     expect(flags.welshTranslation.translatePassTestResult).toBe(false);
+    expect(flags.issueDocsCentrally.enabled).toBe(true);
   });
 
   it('should override some flags with a partial response', async () => {
@@ -23,6 +24,9 @@ describe('app config configuration', () => {
       welshTranslation: {
         enabled: true,
         translatePassTestResult: true,
+      },
+      issueDocsCentrally: {
+        enabled: false,
       },
     };
 
@@ -33,5 +37,6 @@ describe('app config configuration', () => {
     expect(flags.welshTranslation.enabled).toBe(true);
     expect(flags.welshTranslation.translatePassTestResult).toBe(true);
     expect(flags.welshTranslation.translateFailTestResult).toBe(false);
+    expect(flags.issueDocsCentrally.enabled).toBe(false);
   });
 });

--- a/packages/feature-flags/src/profiles/vtx.ts
+++ b/packages/feature-flags/src/profiles/vtx.ts
@@ -9,6 +9,9 @@ const defaultFeatureFlags = {
     translateFailTestResult: false,
     translatePrsTestResult: false,
   },
+  issueDocsCentrally: {
+    enabled: true,
+  },
 };
 
 export type FeatureFlags = typeof defaultFeatureFlags;


### PR DESCRIPTION
## Create Feature flag for centralDocs process in App Config

Feature flag is required for the centralDocs process
Default is ON - emails sent
To go into existing VTx profile

Related issue: [CB2-13187](https://dvsa.atlassian.net/browse/CB2-13187)

## Before submitting (or marking as "ready for review")

- [X] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [X] Have you performed a self-review of the code
- [X] Have you have added tests that prove the fix or feature is effective and working
- [ ] Did you make sure to update any documentation relating to this change?
