### PR TITLE
feat: add new method to generate single api spec object from a file with many

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12256,7 +12256,7 @@
     },
     "packages/aws-utils": {
       "name": "@dvsa/aws-utilities",
-      "version": "1.3.0",
+      "version": "1.3.1",
       "license": "ISC",
       "dependencies": {
         "@aws-sdk/client-cloudwatch-logs": "^3.682.0",
@@ -13058,7 +13058,7 @@
     },
     "packages/openapi-schema-generator": {
       "name": "@dvsa/openapi-schema-generator",
-      "version": "0.1.0",
+      "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
         "openapi3-ts": "^4.4.0"

--- a/packages/biome-config/package.json
+++ b/packages/biome-config/package.json
@@ -2,7 +2,9 @@
   "name": "@dvsa/biome-config",
   "description": "Shareable Biome configuration",
   "version": "0.3.0",
-  "scripts": {},
+  "scripts": {
+    "lint:fix": "echo 'Not implemented'"
+  },
   "author": "DVSA",
   "type": "module",
   "license": "ISC",

--- a/packages/openapi-schema-generator/package.json
+++ b/packages/openapi-schema-generator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dvsa/openapi-schema-generator",
-  "version": "0.1.0",
+  "version": "1.0.0",
   "author": "DVSA",
   "license": "ISC",
   "scripts": {

--- a/packages/openapi-schema-generator/src/__tests__/index.spec.ts
+++ b/packages/openapi-schema-generator/src/__tests__/index.spec.ts
@@ -20,7 +20,7 @@ describe('TypescriptToOpenApiSpec', () => {
 		jest.resetAllMocks();
 	});
 
-	describe('generate', () => {
+	describe('generateMany', () => {
 		it('should generate OpenAPI schema from TypeScript interfaces', async () => {
 			// Mock the extractDefinitions method
 			// biome-ignore lint/suspicious/noExplicitAny: <explanation>
@@ -33,7 +33,7 @@ describe('TypescriptToOpenApiSpec', () => {
 				},
 			});
 
-			const result = await typescriptToOpenApiSpec.generate();
+			const result = await typescriptToOpenApiSpec.generateMany();
 
 			expect(result).toEqual({
 				User: {

--- a/packages/openapi-schema-generator/src/index.ts
+++ b/packages/openapi-schema-generator/src/index.ts
@@ -1,13 +1,13 @@
 import { type SchemaObject } from 'openapi3-ts/oas30';
 import {
-  createProgram,
-  forEachChild,
-  isClassDeclaration,
-  isInterfaceDeclaration,
-  isPropertyDeclaration,
-  isPropertySignature,
-  type Node as TypescriptNode,
-  type TypeChecker,
+	type TypeChecker,
+	type Node as TypescriptNode,
+	createProgram,
+	forEachChild,
+	isClassDeclaration,
+	isInterfaceDeclaration,
+	isPropertyDeclaration,
+	isPropertySignature,
 } from 'typescript';
 
 type OpenAPIDataType = 'string' | 'number' | 'boolean' | 'object' | 'array';


### PR DESCRIPTION
## Description
- Previously, we would pass in a file and every interface or class would be converted to an OpenAPI spec. Whilst this is convenient, we also need the ability to create a single response schema when there are many interfaces in a single file. This PR introduces that

Related issue: [JIRA_TICKET_NUMBER](LINK_TO_JIRA_TICKET)

## Before submitting (or marking as "ready for review")

- [ ] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [ ] Have you performed a self-review of the code
- [ ] Have you have added tests that prove the fix or feature is effective and working
- [ ] Did you make sure to update any documentation relating to this change?
